### PR TITLE
Updated part numbers on WingShield

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,55 @@ tests/*
 *.exe
 *.out
 *.app
+
+# Ignore list for Eagle, a PCB layout tool
+
+# Backup files
+*.s#?
+*.b#?
+*.l#?
+*.b$?
+*.s$?
+*.l$?
+
+# Eagle project file
+# It contains a serial number and references to the file structure
+# on your computer.
+# comment the following line if you want to have your project file included.
+eagle.epf
+
+# Autorouter files
+*.pro
+*.job
+
+# CAM files
+*.$$$
+*.cmp
+*.ly2
+*.l15
+*.sol
+*.plc
+*.stc
+*.sts
+*.crc
+*.crs
+
+*.dri
+*.drl
+*.gpi
+*.pls
+*.ger
+*.xln
+
+*.drd
+*.drd.*
+
+*.s#*
+*.b#*
+
+*.info
+
+*.eps
+
+# file locks introduced since 7.x
+*.lck

--- a/hardware/RS485_Mayfly.brd
+++ b/hardware/RS485_Mayfly.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="8.5.1">
+<eagle version="9.1.3">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -450,6 +450,9 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </packages>
 <packages3d>
 <package3d name="SMT-JUMPER_2_NO_SILK" urn="urn:adsk.eagle:package:39279/1" type="box" library_version="1">
+<packageinstances>
+<packageinstance name="SMT-JUMPER_2_NO_SILK"/>
+</packageinstances>
 </package3d>
 </packages3d>
 </library>
@@ -672,6 +675,9 @@ You are welcome to use this library for commercial purposes. For attribution, we
 Silkscreen logo for open-source hardware designs.
 Devices using:
 OSHW_LOGO</description>
+<packageinstances>
+<packageinstance name="OSHW-LOGO-MINI"/>
+</packageinstances>
 </package3d>
 </packages3d>
 </library>
@@ -765,6 +771,9 @@ design rules under a new name.</description>
 <param name="checkRestrict" value="1"/>
 <param name="checkStop" value="0"/>
 <param name="checkValues" value="0"/>
+<param name="checkNames" value="1"/>
+<param name="checkWireStubs" value="1"/>
+<param name="checkPolygonWidth" value="0"/>
 <param name="useDiameter" value="13"/>
 <param name="maxErrors" value="50"/>
 </designrules>
@@ -866,11 +875,17 @@ design rules under a new name.</description>
 </autorouter>
 <elements>
 <element name="C1" library="bschulz_passives" package="E2,5-6E" value="" x="16.51" y="12.7" smashed="yes" rot="MR270">
+<attribute name="DIGIKEY" value="1189-3597-ND" x="16.51" y="12.7" size="0.8128" layer="28" font="vector" ratio="15" rot="MR270" align="center" display="off"/>
+<attribute name="MF" value="Wurth" x="16.51" y="12.7" size="0.8128" layer="28" font="vector" ratio="15" rot="MR270" align="center" display="off"/>
+<attribute name="MPN" value="6.3ZLQ680MEFC6.3X11" x="16.51" y="12.7" size="0.8128" layer="28" font="vector" ratio="15" rot="MR270" align="center" display="off"/>
 <attribute name="NAME" x="14.986" y="10.033" size="1.27" layer="26" font="vector" ratio="10" rot="MR270"/>
 <attribute name="SPICEPREFIX" value="C" x="16.51" y="12.7" size="1.778" layer="28" rot="MR270" display="off"/>
 <attribute name="VALUE" x="19.05" y="10.033" size="1.27" layer="28" ratio="10" rot="MR270"/>
 </element>
 <element name="C2" library="bschulz_passives" package="E2,5-6E" value="" x="8.89" y="12.7" smashed="yes" rot="MR270">
+<attribute name="DIGIKEY" value="1189-3597-ND" x="8.89" y="12.7" size="0.8128" layer="28" font="vector" ratio="15" rot="MR270" align="center" display="off"/>
+<attribute name="MF" value="Wurth" x="8.89" y="12.7" size="0.8128" layer="28" font="vector" ratio="15" rot="MR270" align="center" display="off"/>
+<attribute name="MPN" value="6.3ZLQ680MEFC6.3X11" x="8.89" y="12.7" size="0.8128" layer="28" font="vector" ratio="15" rot="MR270" align="center" display="off"/>
 <attribute name="NAME" x="7.366" y="10.033" size="1.27" layer="26" font="vector" ratio="10" rot="MR270"/>
 <attribute name="SPICEPREFIX" value="C" x="8.89" y="12.7" size="1.778" layer="28" rot="MR270" display="off"/>
 <attribute name="VALUE" x="11.43" y="10.033" size="1.27" layer="28" ratio="10" rot="MR270"/>
@@ -884,6 +899,9 @@ design rules under a new name.</description>
 <attribute name="NAME" x="26.771" y="18.123" size="0.8128" layer="33" font="vector" ratio="10" rot="R180"/>
 </element>
 <element name="J4" library="bschulz" package="2X10" value="" x="10.414" y="4.572" smashed="yes" rot="MR180">
+<attribute name="DIGIKEY" value="S2011EC-10-ND" x="10.414" y="4.572" size="1.778" layer="28" rot="MR180" display="off"/>
+<attribute name="MF" value="Sullins" x="10.414" y="4.572" size="1.778" layer="28" rot="MR180" display="off"/>
+<attribute name="MPN" value="PRPC010DAAN-RC" x="10.414" y="4.572" size="1.778" layer="28" rot="MR180" display="off"/>
 <attribute name="NAME" x="8.001" y="1.27" size="0.6096" layer="26" font="vector" ratio="20" rot="MR180"/>
 <attribute name="VALUE" x="9.144" y="6.985" size="0.6096" layer="28" font="vector" ratio="20" rot="MR180"/>
 </element>
@@ -893,9 +911,21 @@ design rules under a new name.</description>
 <attribute name="NAME" x="28.305" y="16.977" size="0.8128" layer="25" font="vector" ratio="15" rot="R180"/>
 <attribute name="NAME" x="38.709" y="18.123" size="0.8128" layer="33" font="vector" ratio="10" rot="R180"/>
 </element>
-<element name="J5" library="bschulz" package="1X04_NOSILK" value="CONN_42.54_NOSILK" x="10.033" y="21.844" smashed="yes" rot="R180"/>
-<element name="J6" library="bschulz" package="1X04_NOSILK" value="CONN_42.54_NOSILK" x="21.971" y="21.844" smashed="yes" rot="R180"/>
-<element name="J7" library="bschulz" package="1X04_NOSILK" value="CONN_42.54_NOSILK" x="33.909" y="21.844" smashed="yes" rot="R180"/>
+<element name="J5" library="bschulz" package="1X04_NOSILK" value="CONN_42.54_NOSILK" x="10.033" y="21.844" smashed="yes" rot="R180">
+<attribute name="DIGIKEY" value="ED10563-ND" x="10.033" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+<attribute name="MF" value="On Shore" x="10.033" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+<attribute name="MPN" value="OSTVN04A150" x="10.033" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+</element>
+<element name="J6" library="bschulz" package="1X04_NOSILK" value="CONN_42.54_NOSILK" x="21.971" y="21.844" smashed="yes" rot="R180">
+<attribute name="DIGIKEY" value="ED10563-ND" x="21.971" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+<attribute name="MF" value="On Shore" x="21.971" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+<attribute name="MPN" value="OSTVN04A150" x="21.971" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+</element>
+<element name="J7" library="bschulz" package="1X04_NOSILK" value="CONN_42.54_NOSILK" x="33.909" y="21.844" smashed="yes" rot="R180">
+<attribute name="DIGIKEY" value="ED10563-ND" x="33.909" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+<attribute name="MF" value="On Shore" x="33.909" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+<attribute name="MPN" value="OSTVN04A150" x="33.909" y="21.844" size="0.8128" layer="27" font="vector" ratio="15" rot="R180" align="center" display="off"/>
+</element>
 <element name="JP1" library="SparkFun-Jumpers" library_urn="urn:adsk.eagle:library:528" package="SMT-JUMPER_2_NO_SILK" package3d_urn="urn:adsk.eagle:package:39279/1" value="JUMPER-SMT_2_NO_SILK" x="25.654" y="11.43" smashed="yes" rot="MR90">
 <attribute name="NAME" x="25.654" y="9.271" size="0.6096" layer="26" font="vector" ratio="20" rot="MR0" align="bottom-center"/>
 </element>
@@ -1059,6 +1089,13 @@ design rules under a new name.</description>
 <wire x1="25.781" y1="21.844" x2="25.781" y2="20.193" width="0.4064" layer="1"/>
 </signal>
 </signals>
+<mfgpreviewcolors>
+<mfgpreviewcolor name="soldermaskcolor" color="0xC8008000"/>
+<mfgpreviewcolor name="silkscreencolor" color="0xFFFEFEFE"/>
+<mfgpreviewcolor name="backgroundcolor" color="0xFF282828"/>
+<mfgpreviewcolor name="coppercolor" color="0xFFFFBF00"/>
+<mfgpreviewcolor name="substratecolor" color="0xFF786E46"/>
+</mfgpreviewcolors>
 </board>
 </drawing>
 <compatibility>

--- a/hardware/RS485_Mayfly.sch
+++ b/hardware/RS485_Mayfly.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="8.5.1">
+<eagle version="9.1.3">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -8,34 +8,34 @@
 </settings>
 <grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
-<layer number="1" name="Top" color="4" fill="1" visible="no" active="no"/>
-<layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
-<layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
-<layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
-<layer number="5" name="Route5" color="4" fill="4" visible="no" active="no"/>
-<layer number="6" name="Route6" color="1" fill="8" visible="no" active="no"/>
-<layer number="7" name="Route7" color="4" fill="8" visible="no" active="no"/>
-<layer number="8" name="Route8" color="1" fill="2" visible="no" active="no"/>
-<layer number="9" name="Route9" color="4" fill="2" visible="no" active="no"/>
-<layer number="10" name="Route10" color="1" fill="7" visible="no" active="no"/>
-<layer number="11" name="Route11" color="4" fill="7" visible="no" active="no"/>
-<layer number="12" name="Route12" color="1" fill="5" visible="no" active="no"/>
-<layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
-<layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
-<layer number="15" name="Route15" color="4" fill="6" visible="no" active="no"/>
-<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="no"/>
-<layer number="17" name="Pads" color="2" fill="1" visible="no" active="no"/>
-<layer number="18" name="Vias" color="2" fill="1" visible="no" active="no"/>
-<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="no"/>
-<layer number="20" name="Dimension" color="24" fill="1" visible="no" active="no"/>
-<layer number="21" name="tPlace" color="7" fill="1" visible="no" active="no"/>
-<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="no"/>
-<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="no"/>
-<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="no"/>
-<layer number="25" name="tNames" color="7" fill="1" visible="no" active="no"/>
-<layer number="26" name="bNames" color="7" fill="1" visible="no" active="no"/>
-<layer number="27" name="tValues" color="7" fill="1" visible="no" active="no"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="no"/>
+<layer number="2" name="Route2" color="1" fill="3" visible="yes" active="no"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="yes" active="no"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="yes" active="no"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="yes" active="no"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="yes" active="no"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="yes" active="no"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="yes" active="no"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="yes" active="no"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="yes" active="no"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="yes" active="no"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="yes" active="no"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="yes" active="no"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="yes" active="no"/>
+<layer number="15" name="Route15" color="4" fill="6" visible="yes" active="no"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="no"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="no"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="no"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="no"/>
+<layer number="20" name="Dimension" color="24" fill="1" visible="yes" active="no"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="no"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="no"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="no"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="no"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="yes" active="no"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="no"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="no"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="no"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="no"/>
 <layer number="30" name="bStop" color="7" fill="6" visible="no" active="no"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="no" active="no"/>
@@ -44,8 +44,8 @@
 <layer number="34" name="bFinish" color="6" fill="6" visible="no" active="no"/>
 <layer number="35" name="tGlue" color="7" fill="4" visible="no" active="no"/>
 <layer number="36" name="bGlue" color="7" fill="5" visible="no" active="no"/>
-<layer number="37" name="tTest" color="7" fill="1" visible="no" active="no"/>
-<layer number="38" name="bTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="yes" active="no"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="yes" active="no"/>
 <layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="no"/>
 <layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="no"/>
 <layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="no"/>
@@ -53,19 +53,19 @@
 <layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="no"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="no" active="no"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="no" active="no"/>
-<layer number="46" name="Milling" color="3" fill="1" visible="no" active="no"/>
-<layer number="47" name="Measures" color="7" fill="1" visible="no" active="no"/>
-<layer number="48" name="Document" color="7" fill="1" visible="no" active="no"/>
-<layer number="49" name="Reference" color="7" fill="1" visible="no" active="no"/>
-<layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
-<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="no"/>
-<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="no"/>
-<layer number="53" name="tGND_GNDA" color="7" fill="1" visible="no" active="no"/>
-<layer number="54" name="bGND_GNDA" color="7" fill="1" visible="no" active="no"/>
-<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
-<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
-<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
-<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="yes" active="no"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="yes" active="no"/>
+<layer number="48" name="Document" color="7" fill="1" visible="yes" active="no"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="yes" active="no"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="yes" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="no"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="no"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="1" visible="yes" active="no"/>
+<layer number="54" name="bGND_GNDA" color="7" fill="1" visible="yes" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="yes" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="yes" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="yes" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="yes" active="no"/>
 <layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
 <layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
@@ -7859,7 +7859,16 @@ This was SPECIALLY designed to be used with our Graphic LCD Backpack.  Be sure y
 <connect gate="G$1" pin="9" pad="9"/>
 </connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="DIGIKEY" value="" constant="no"/>
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="" constant="no"/>
+</technology>
+<technology name="MALE">
+<attribute name="DIGIKEY" value="S2011EC-10-ND" constant="no"/>
+<attribute name="MF" value="Sullins" constant="no"/>
+<attribute name="MPN" value="PRPC010DAAN-RC" constant="no"/>
+</technology>
 </technologies>
 </device>
 <device name="2X10_LOCK" package="2X10_LOCK">
@@ -7945,7 +7954,7 @@ This was SPECIALLY designed to be used with our Graphic LCD Backpack.  Be sure y
 </device>
 </devices>
 </deviceset>
-<deviceset name="CONN_4">
+<deviceset name="CONN_4" prefix="J">
 <description>Genaric 4 pin connector</description>
 <gates>
 <gate name="G$1" symbol="CONN_04" x="2.54" y="-2.54"/>
@@ -7959,7 +7968,11 @@ This was SPECIALLY designed to be used with our Graphic LCD Backpack.  Be sure y
 <connect gate="G$1" pin="4" pad="4"/>
 </connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="DIGIKEY" value="ED10563-ND" constant="no"/>
+<attribute name="MF" value="On Shore" constant="no"/>
+<attribute name="MPN" value="OSTVN04A150" constant="no"/>
+</technology>
 </technologies>
 </device>
 <device name="2.54" package="1X04">
@@ -8070,13 +8083,25 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </package>
 </packages>
 <packages3d>
+<package3d name="SMT-JUMPER_2_NO_SILK" urn="urn:adsk.eagle:package:39279/1" type="box" library_version="1">
+<packageinstances>
+<packageinstance name="SMT-JUMPER_2_NO_SILK"/>
+</packageinstances>
+</package3d>
 <package3d name="SMT-JUMPER_2_NO_NO-SILK" urn="urn:adsk.eagle:package:39277/1" type="box" library_version="1">
+<packageinstances>
+<packageinstance name="SMT-JUMPER_2_NO_NO-SILK"/>
+</packageinstances>
 </package3d>
 <package3d name="SMT-JUMPER_2_NO_NO-SILK_ROUND" urn="urn:adsk.eagle:package:39278/1" type="box" library_version="1">
-</package3d>
-<package3d name="SMT-JUMPER_2_NO_SILK" urn="urn:adsk.eagle:package:39279/1" type="box" library_version="1">
+<packageinstances>
+<packageinstance name="SMT-JUMPER_2_NO_NO-SILK_ROUND"/>
+</packageinstances>
 </package3d>
 <package3d name="SMT-JUMPER_2_NO_SILK_ROUND" urn="urn:adsk.eagle:package:39280/1" type="box" library_version="1">
+<packageinstances>
+<packageinstance name="SMT-JUMPER_2_NO_SILK_ROUND"/>
+</packageinstances>
 </package3d>
 </packages3d>
 <symbols>
@@ -8616,47 +8641,68 @@ You are welcome to use this library for commercial purposes. For attribution, we
 </package>
 </packages>
 <packages3d>
+<package3d name="OSHW-LOGO-MINI" urn="urn:adsk.eagle:package:37101/1" type="box" library_version="1">
+<description>Open-Source Hardware (OSHW) Logo - Mini - Silkscreen
+Silkscreen logo for open-source hardware designs.
+Devices using:
+OSHW_LOGO</description>
+<packageinstances>
+<packageinstance name="OSHW-LOGO-MINI"/>
+</packageinstances>
+</package3d>
 <package3d name="OSHW-LOGO-S_COPPER" urn="urn:adsk.eagle:package:37100/1" type="box" library_version="1">
 <description>Open-Source Hardware (OSHW) Logo - Small - Top Copper
 Exposed copper logo for open-source hardware designs.
 Devices using:
 OSHW_LOGO</description>
+<packageinstances>
+<packageinstance name="OSHW-LOGO-S_COPPER"/>
+</packageinstances>
 </package3d>
 <package3d name="OSHW-LOGO-M_COPPER" urn="urn:adsk.eagle:package:37119/1" type="box" library_version="1">
 <description>Open-Source Hardware (OSHW) Logo - Medium - Top Copper
 Exposed copper logo for open-source hardware designs.
 Devices using:
 OSHW_LOGO</description>
+<packageinstances>
+<packageinstance name="OSHW-LOGO-M_COPPER"/>
+</packageinstances>
 </package3d>
 <package3d name="OSHW-LOGO-L_COPPER" urn="urn:adsk.eagle:package:37117/1" type="box" library_version="1">
 <description>Open-Source Hardware (OSHW) Logo - Large - Top Copper
 Exposed copper logo for open-source hardware designs.
 Devices using:
 OSHW_LOGO</description>
+<packageinstances>
+<packageinstance name="OSHW-LOGO-L_COPPER"/>
+</packageinstances>
 </package3d>
 <package3d name="OSHW-LOGO-L" urn="urn:adsk.eagle:package:37097/1" type="box" library_version="1">
 <description>Open-Source Hardware (OSHW) Logo - Large - Silkscreen
 Silkscreen logo for open-source hardware designs.
 Devices using:
 OSHW_LOGO</description>
+<packageinstances>
+<packageinstance name="OSHW-LOGO-L"/>
+</packageinstances>
 </package3d>
 <package3d name="OSHW-LOGO-M" urn="urn:adsk.eagle:package:37126/1" type="box" library_version="1">
 <description>Open-Source Hardware (OSHW) Logo - Medium - Silkscreen
 Silkscreen logo for open-source hardware designs.
 Devices using:
 OSHW_LOGO</description>
+<packageinstances>
+<packageinstance name="OSHW-LOGO-M"/>
+</packageinstances>
 </package3d>
 <package3d name="OSHW-LOGO-S" urn="urn:adsk.eagle:package:37099/1" type="box" library_version="1">
 <description>Open-Source Hardware (OSHW) Logo - Small - Silkscreen
 Silkscreen logo for open-source hardware designs.
 Devices using:
 OSHW_LOGO</description>
-</package3d>
-<package3d name="OSHW-LOGO-MINI" urn="urn:adsk.eagle:package:37101/1" type="box" library_version="1">
-<description>Open-Source Hardware (OSHW) Logo - Mini - Silkscreen
-Silkscreen logo for open-source hardware designs.
-Devices using:
-OSHW_LOGO</description>
+<packageinstances>
+<packageinstance name="OSHW-LOGO-S"/>
+</packageinstances>
 </package3d>
 </packages3d>
 <symbols>
@@ -12303,7 +12349,7 @@ OSHW_LOGO</description>
 <part name="J1" library="Limnotech" deviceset="TWIG-2.0-DIP" device=""/>
 <part name="J2" library="Limnotech" deviceset="TWIG-2.0-DIP" device=""/>
 <part name="GND1" library="SparkFun-PowerSymbols" library_urn="urn:adsk.eagle:library:530" deviceset="GND" device=""/>
-<part name="J4" library="bschulz" deviceset="CONN_10X2" device=""/>
+<part name="J4" library="bschulz" deviceset="CONN_10X2" device="" technology="MALE"/>
 <part name="J3" library="Limnotech" deviceset="TWIG-2.0-DIP" device=""/>
 <part name="J5" library="bschulz" deviceset="CONN_4" device="2.54_NOSILK" value="CONN_42.54_NOSILK"/>
 <part name="J6" library="bschulz" deviceset="CONN_4" device="2.54_NOSILK" value="CONN_42.54_NOSILK"/>


### PR DESCRIPTION
Added part numbers in the Eagle file for the capacitors and connectors on the WIngShield, still need to add full BOM for system eventually.

This is from a commit that @bschulz1701 made to the `hardware` branch on Sept. 19, 2018 connected to his comment in https://github.com/EnviroDIY/SensorModbusMaster/issues/5#issuecomment-422569093.

I think none of us realized that his commit wasn't on the master branch! It is now.