### PR TITLE
Bugfixes and a new example for release 0.7.2

### DIFF
--- a/examples/getSetAddress/ReadMe.md
+++ b/examples/getSetAddress/ReadMe.md
@@ -1,0 +1,16 @@
+# Getting and Setting a Modbus Address<!-- {#example_read_write_register} -->
+
+This example gets the Modbus address for a sensor and optionally
+sets it to a new address. This example can be used on sensors from
+any manufacturer, as long as you know the register for the device address.
+
+_______
+
+
+[//]: # ( @section example_get_set_address_pio_config PlatformIO Configuration )
+
+[//]: # ( @include{lineno} getSetAddress/platformio.ini )
+
+[//]: # ( @section example_get_set_address_pio_code The Complete Code )
+
+[//]: # ( @include{lineno} getSetAddress/getSetAddress.ino )

--- a/examples/getSetAddress/getSetAddress.ino
+++ b/examples/getSetAddress/getSetAddress.ino
@@ -256,58 +256,8 @@ void setup() {
 }
 
 // ==========================================================================
-// Main loop function
+//  Arduino Loop Function
 // ==========================================================================
 void loop() {
-    // // Get data values from read-only input registers (0x04)
-    // // Just for show, we will do the exact same thing 2 ways
-    // // All values will be read as bigEndian
-
-    // // Some variables to hold results
-    // uint16_t deviceStatus = 0;
-    // int16_t  doPPM        = 0;
-    // uint16_t temperature  = 0;
-
-    // // Method 1:
-    // // Get three values one at a time from 3 different registers.
-    // // This code is easier to follow, but it requires more back-and-forth between
-    // // the Arduino and the sensor so it is a little "slower".
-    // deviceStatus = modbus.uint16FromRegister(0x04, 0x00, bigEndian);
-    // doPPM        = modbus.int16FromRegister(0x04, 0x01, bigEndian);
-    // temperature  = modbus.uint16FromRegister(0x04, 0x02, bigEndian);
-
-    // // Print results
-    // Serial.print("Device Status:");
-    // Serial.println(deviceStatus);
-    // Serial.print("Dissolved Oxygen in ppm:");
-    // Serial.println(doPPM);
-    // Serial.print("Temperature in °C:");
-    // Serial.println(temperature);
-    // Serial.println();
-
-    // // Method 2:
-    // // Read all three registers at once and parse the values from the response.
-    // // This is faster, especially when getting many readings, but it's trickier to
-    // // write and understand the code.
-    // bool success = modbus.getRegisters(0x04, 0x00, 3);
-    // // ^ This gets the values and stores them in an internal "frame" with the hex values
-    // // of the response
-    // if (success) {
-    //     deviceStatus = modbus.uint16FromFrame(bigEndian, 3);
-    //     // ^ The first data value is at position 3 in the modbus response frame
-    //     // 0 = modbus address, 1 = modbus method, 2 = # registers returned, 3 = 1st
-    //     // value returned
-    //     doPPM = modbus.int16FromFrame(bigEndian, 5);
-    //     // ^ The next data value is at position 5 since each register occupies 2 places
-    //     temperature = modbus.uint16FromFrame(bigEndian, 7);
-    // }
-
-    // // Print results
-    // Serial.print("Device Status:");
-    // Serial.println(deviceStatus);
-    // Serial.print("Dissolved Oxygen in ppm:");
-    // Serial.println(doPPM);
-    // Serial.print("Temperature in °C:");
-    // Serial.println(temperature);
-    // Serial.println();
+    // This all runs from setup!
 }

--- a/examples/getSetAddress/platformio.ini
+++ b/examples/getSetAddress/platformio.ini
@@ -1,0 +1,21 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+description = Gettting and/or setting the Modbus address for a device
+src_dir = examples/getSetAddress
+
+[env:mayfly]
+monitor_speed = 57600
+board = mayfly
+platform = atmelavr
+framework = arduino
+lib_deps =
+    SensorModbusMaster

--- a/examples/readWriteRegister/readWriteRegister.ino
+++ b/examples/readWriteRegister/readWriteRegister.ino
@@ -182,16 +182,16 @@ void setup() {
     Serial.print(F(", hexidecimal: "));
     Serial.println(prettyprintAddressHex(modbusAddress));
 
-    // // Write to a holding register
-    // // In this case, we are changing the output units of a dissolved oxygen sensor
-    // Serial.println("Setting DO units to ppm");
-    // modbus.int16ToRegister(0x01, 1, bigEndian);
-    // // Verify that the register changed
-    // // 0x03 = holding register
-    // // only holding registers are writeable
-    // int16_t doUnitMode = modbus.int16FromRegister(0x03, 0x01, bigEndian);
-    // Serial.print("Current unit mode is ");
-    // Serial.println(doUnitMode);
+    // Write to a holding register
+    // In this case, we are changing the output units of a dissolved oxygen sensor
+    Serial.println("Setting DO units to ppm");
+    modbus.int16ToRegister(0x01, 1, bigEndian);
+    // Verify that the register changed
+    // 0x03 = holding register
+    // only holding registers are writeable
+    int16_t doUnitMode = modbus.int16FromRegister(0x03, 0x01, bigEndian);
+    Serial.print("Current unit mode is ");
+    Serial.println(doUnitMode);
 }
 
 // ==========================================================================

--- a/src/SensorModbusMaster.cpp
+++ b/src/SensorModbusMaster.cpp
@@ -734,7 +734,7 @@ void modbusMaster::printFrameHex(byte modbusFrame[], int frameLength) {
     for (int i = 0; i < frameLength; i++) {
         debugPrint("0x");
         if (modbusFrame[i] < 16) debugPrint("0");
-        debugPrint(modbusFrame[i], HEX);
+        debugPrint(String(modbusFrame[i], HEX));
         if (i < frameLength - 1) debugPrint(", ");
     }
     debugPrint("}\n");


### PR DESCRIPTION
This PR fixes two bugs present in v0.7.1.
- #29 
- The `readWriteRegister.ino` example wouldn't work with AltSoftSerial (see d4204ebd1212608aaf05a7a65b763e432c59fe37 and https://github.com/EnviroDIY/SensorModbusMaster/commit/f1daa2fdd22c7ec991fc2ff50330aa41e4a7a53e)

I also added a new example with very valuable functionality:
- #30

@SRGDamia1, please review a soon as you can for a bugfix release, as getting a new tag in the PlatformIO Library Registry will be important for users of other libraries that depend on this one.